### PR TITLE
Add fallback for undefined path

### DIFF
--- a/js/development-overlay.js
+++ b/js/development-overlay.js
@@ -27,7 +27,7 @@
   }
 
   // Add src to image.
-  image.src = feDevelopmentOverlay.path + '/' + src;
+  image.src = getImgSrcValue(src);
 
   // Update CSS.
   Object.keys(properties).forEach(function(key) {
@@ -82,6 +82,18 @@
 
   function needsPx(key) {
     return -1 !== propertiesThatNeedPx.indexOf(key);
+  }
+
+  function getImgSrcValue(src) {
+    if (
+      'undefined' !== typeof feDevelopmentOverlay &&
+      'undefined' !== typeof feDevelopmentOverlay.path
+    ) {
+      // Use path provided by feDevelopmentOverlay (via WordPress).
+      return feDevelopmentOverlay.path + '/' + src;
+    }
+    // Use default path.
+    return './overlay/' + src;
   }
 
 }());


### PR DESCRIPTION
Since this code was originally written as a WordPress plugin, we are
passing in the path to use via the JavaScript property
feDevelopmentOverlay.path

However, in an effort to make the JavaScript file in this project
capable of being used as a stand-alone file (e.g. in a static website
project that does not involve WordPress), we are adding a fallback value for
when the object and/or property are not defined is added.

We're adding the getImgSrcValue() function, we checks for the WordPress
provided path and uses it when present but falls back to the path
'./overlay/' as a default.

See #1