### PR TITLE
Add comment to top of JS file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changelog
 - Keyboard support, ESC key toggle overlay
 - Add default image path (./overlay/) for projects without WordPress
+- Add comment to top of JavaScript file for stand-alone use
 
 ## [0.1.0] - 2018-07-14
 ### Added

--- a/js/development-overlay.js
+++ b/js/development-overlay.js
@@ -1,3 +1,10 @@
+/**
+ * Development Overlay
+ * Overlay an image on your page during development.
+ * https://salferrarello.com/wordpress-development-overlay/
+ * by Sal Ferrarello
+ * Version: 0.1.0
+ */
 (function() {
 
   var css = 'left: 50%; ',


### PR DESCRIPTION
Add comment to top of JavaScript file, for when the JavaScript file is used as
a stand alone file in a project (i.e. not as a WordPress plugin).

See #8